### PR TITLE
improvement: add the flag to make ts-node-dev ignore transpilation er…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "yarn build && node dist/src/index.js",
-    "start:local": "ts-node-dev 'src/index.ts' | pino-pretty -c",
+    "start:local": "ts-node-dev --transpile-only 'src/index.ts' | pino-pretty -c",
     "test": "yarn lint && yarn style:check && yarn test:unit && yarn test:functional",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint ./src ./test --ext .ts --fix",


### PR DESCRIPTION
add the flag --transpile-only to make ts-node-dev ignore errors on transpile and avoid the errors on custom types (express extension interface).

Closes #9