### PR TITLE
Implement cache in stormGlass service to fetchPoints function

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -7,7 +7,8 @@
     "resources": {
       "StormGlass": {
         "apiUrl": "STORM_GLASS_API_URL",
-        "apiToken": "STORM_GLASS_API_TOKEN"
+        "apiToken": "STORM_GLASS_API_TOKEN",
+        "cacheApiTtl": "STORM_GLASS_API_CACHE_TTL"
       }
     },
     "auth": {

--- a/config/default.json
+++ b/config/default.json
@@ -11,7 +11,8 @@
     "resources": {
       "StormGlass": {
         "apiUrl": "https://api.stormglass.io/v2",
-        "apiToken": "do-not-hard-code"
+        "apiToken": "do-not-hard-code",
+        "cacheTtl": 3600
       }
     },
     "logger": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "module-alias": "^2.2.2",
     "moment": "^2.27.0",
     "mongoose": "^5.9.18",
+    "node-cache": "^5.1.2",
     "pino": "^6.3.2",
     "swagger-ui-express": "^4.1.4"
   },
@@ -70,6 +71,7 @@
     "@types/multer": "^1.4.3",
     "@types/nock": "^11.1.0",
     "@types/node": "^13.13.2",
+    "@types/node-cache": "^4.2.5",
     "@types/pino": "^6.3.0",
     "@types/supertest": "^2.0.9",
     "@types/swagger-ui-express": "^4.1.2",

--- a/src/clients/__test__/stormGlass.test.ts
+++ b/src/clients/__test__/stormGlass.test.ts
@@ -2,9 +2,10 @@ import { StormGlass } from '@src/clients/stormGlass';
 import stormglassNormalizedResponseFixture from '@test/fixtures/stormglass_normalized_response_3_hours.json';
 import * as stormglassWeatherPointFixture from '@test/fixtures/stormglass_weather_3_hours.json';
 import * as HTTPUtil from '@src/util/request';
-import { CacheUtil } from '@src/util/cache';
+import CacheUtil from '@src/util/cache';
 
 jest.mock('@src/util/request');
+jest.mock('@src/util/cache');
 
 describe('StormGlass client', () => {
   /**
@@ -17,7 +18,7 @@ describe('StormGlass client', () => {
    * Used for instance method's mocks
    */
   const mockedRequest = new HTTPUtil.Request() as jest.Mocked<HTTPUtil.Request>;
-  const mockedCache = new CacheUtil() as jest.Mocked<CacheUtil>;
+  const mockedCache = CacheUtil;
   it('should return the normalized forecast from the StormGlass service', async () => {
     const lat = -33.792726;
     const lng = 151.289824;

--- a/src/clients/__test__/stormGlass.test.ts
+++ b/src/clients/__test__/stormGlass.test.ts
@@ -2,6 +2,7 @@ import { StormGlass } from '@src/clients/stormGlass';
 import stormglassNormalizedResponseFixture from '@test/fixtures/stormglass_normalized_response_3_hours.json';
 import * as stormglassWeatherPointFixture from '@test/fixtures/stormglass_weather_3_hours.json';
 import * as HTTPUtil from '@src/util/request';
+import { CacheUtil } from '@src/util/cache';
 
 jest.mock('@src/util/request');
 
@@ -16,6 +17,7 @@ describe('StormGlass client', () => {
    * Used for instance method's mocks
    */
   const mockedRequest = new HTTPUtil.Request() as jest.Mocked<HTTPUtil.Request>;
+  const mockedCache = new CacheUtil() as jest.Mocked<CacheUtil>;
   it('should return the normalized forecast from the StormGlass service', async () => {
     const lat = -33.792726;
     const lng = 151.289824;
@@ -46,7 +48,9 @@ describe('StormGlass client', () => {
       data: incompleteResponse,
     } as HTTPUtil.Response);
 
-    const stormGlass = new StormGlass(mockedRequest);
+    mockedCache.get = jest.fn().mockReturnValue(undefined);
+
+    const stormGlass = new StormGlass(mockedRequest, mockedCache);
     const response = await stormGlass.fetchPoints(lat, lng);
 
     expect(response).toEqual([]);

--- a/src/clients/stormGlass.ts
+++ b/src/clients/stormGlass.ts
@@ -83,12 +83,12 @@ export class StormGlass {
   ) {}
 
   public async fetchPoints(lat: number, lng: number): Promise<ForecastPoint[]> {
-    const cachedForecastPoints = this.getForecastPointsFromCache(lat, lng);
+    const cachedForecastPoints = this.getForecastPointsFromCache(this.getCacheKey(lat, lng));
 
     if (!cachedForecastPoints) {
       const forecastPoints = await this.getForecastPointsFromApi(lat, lng);
       this.setForecastPointsInCache(
-        `forecast_points_${lat}_${lng}`,
+        this.getCacheKey(lat, lng),
         forecastPoints
       );
       return forecastPoints;
@@ -132,21 +132,22 @@ export class StormGlass {
   }
 
   protected getForecastPointsFromCache(
-    lat: number,
-    lng: number
+    key: string
   ): ForecastPoint[] | undefined {
-    const forecastPointCache = this.cacheUtil.get<ForecastPoint[]>(
-      `forecast_points_${lat}_${lng}`
-    );
+    const forecastPointsFromCache = this.cacheUtil.get<ForecastPoint[]>(key);
 
-    if (!forecastPointCache) {
+    if (!forecastPointsFromCache) {
       return;
     }
 
     logger.info(
-      `Using cache to return forecast points for lat: ${lat} and lng: ${lng}`
+      `Using cache to return forecast points for key: ${key}`
     );
-    return forecastPointCache;
+    return forecastPointsFromCache;
+  }
+
+  private getCacheKey(lat: number, lng: number): string {
+    return `forecast_points_${lat}_${lng}`
   }
 
   private setForecastPointsInCache(

--- a/src/clients/stormGlass.ts
+++ b/src/clients/stormGlass.ts
@@ -83,9 +83,9 @@ export class StormGlass {
   ) {}
 
   public async fetchPoints(lat: number, lng: number): Promise<ForecastPoint[]> {
-    const cacheForecastPoints = this.getForecastPointsFromCache(lat, lng);
+    const cachedForecastPoints = this.getForecastPointsFromCache(lat, lng);
 
-    if (!cacheForecastPoints) {
+    if (!cachedForecastPoints) {
       const forecastPoints = await this.getForecastPointsFromApi(lat, lng);
       this.setForecastPointsInCache(
         `forecast_points_${lat}_${lng}`,
@@ -94,7 +94,7 @@ export class StormGlass {
       return forecastPoints;
     }
 
-    return cacheForecastPoints;
+    return cachedForecastPoints;
   }
 
   protected async getForecastPointsFromApi(

--- a/src/clients/stormGlass.ts
+++ b/src/clients/stormGlass.ts
@@ -79,18 +79,17 @@ export class StormGlass {
 
   constructor(
     protected request = new HTTPUtil.Request(),
-    protected cacheUtil = CacheUtil,
+    protected cacheUtil = CacheUtil
   ) {}
 
   public async fetchPoints(lat: number, lng: number): Promise<ForecastPoint[]> {
-    const cachedForecastPoints = this.getForecastPointsFromCache(this.getCacheKey(lat, lng));
+    const cachedForecastPoints = this.getForecastPointsFromCache(
+      this.getCacheKey(lat, lng)
+    );
 
     if (!cachedForecastPoints) {
       const forecastPoints = await this.getForecastPointsFromApi(lat, lng);
-      this.setForecastPointsInCache(
-        this.getCacheKey(lat, lng),
-        forecastPoints
-      );
+      this.setForecastPointsInCache(this.getCacheKey(lat, lng), forecastPoints);
       return forecastPoints;
     }
 
@@ -140,14 +139,12 @@ export class StormGlass {
       return;
     }
 
-    logger.info(
-      `Using cache to return forecast points for key: ${key}`
-    );
+    logger.info(`Using cache to return forecast points for key: ${key}`);
     return forecastPointsFromCache;
   }
 
   private getCacheKey(lat: number, lng: number): string {
-    return `forecast_points_${lat}_${lng}`
+    return `forecast_points_${lat}_${lng}`;
   }
 
   private setForecastPointsInCache(

--- a/src/clients/stormGlass.ts
+++ b/src/clients/stormGlass.ts
@@ -3,7 +3,7 @@ import config, { IConfig } from 'config';
 // Another way to have similar behaviour to TS namespaces
 import * as HTTPUtil from '@src/util/request';
 import { TimeUtil } from '@src/util/time';
-import { CacheUtil } from '@src/util/cache';
+import CacheUtil from '@src/util/cache';
 import logger from '@src/logger';
 
 export interface StormGlassPointSource {
@@ -79,7 +79,7 @@ export class StormGlass {
 
   constructor(
     protected request = new HTTPUtil.Request(),
-    protected cacheUtil = new CacheUtil()
+    protected cacheUtil = CacheUtil,
   ) {}
 
   public async fetchPoints(lat: number, lng: number): Promise<ForecastPoint[]> {

--- a/src/clients/stormGlass.ts
+++ b/src/clients/stormGlass.ts
@@ -97,7 +97,7 @@ export class StormGlass {
     return cacheForecastPoints;
   }
 
-  public async getForecastPointsFromApi(
+  protected async getForecastPointsFromApi(
     lat: number,
     lng: number
   ): Promise<ForecastPoint[]> {
@@ -131,7 +131,7 @@ export class StormGlass {
     }
   }
 
-  public getForecastPointsFromCache(
+  protected getForecastPointsFromCache(
     lat: number,
     lng: number
   ): ForecastPoint[] | undefined {

--- a/src/middlewares/api-error-validator.ts
+++ b/src/middlewares/api-error-validator.ts
@@ -1,10 +1,11 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Request, Response, NextFunction } from 'express';
 import ApiError from '@src/util/errors/api-error';
 
 export interface HTTPError extends Error {
   status?: number;
 }
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 export function apiErrorValidator(
   error: HTTPError,
   _: Partial<Request>,

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -1,6 +1,6 @@
 import NodeCache from 'node-cache';
 
-export class CacheUtil {
+class CacheUtil {
   constructor(protected cacheService = new NodeCache()) {}
 
   // TTL in seconds
@@ -8,9 +8,9 @@ export class CacheUtil {
     return this.cacheService.set(key, value, ttl);
   }
 
-  public get<T>(key: string): T {
-    const value = this.cacheService.get(key);
-
-    return value as T;
+  public get<T>(key: string): T | undefined {
+    return this.cacheService.get<T>(key);
   }
 }
+
+export default new CacheUtil()

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -11,6 +11,10 @@ class CacheUtil {
   public get<T>(key: string): T | undefined {
     return this.cacheService.get<T>(key);
   }
+
+  public clearAllCache(): void {
+    return this.cacheService.flushAll();
+  }
 }
 
-export default new CacheUtil()
+export default new CacheUtil();

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -1,0 +1,16 @@
+import NodeCache from 'node-cache';
+
+export class CacheUtil {
+  constructor(protected cacheService = new NodeCache()) {}
+
+  // TTL in seconds
+  public set<T>(key: string, value: T, ttl = 3600): boolean {
+    return this.cacheService.set(key, value, ttl);
+  }
+
+  public get<T>(key: string): T {
+    const value = this.cacheService.get(key);
+
+    return value as T;
+  }
+}

--- a/test/functional/forecast.test.ts
+++ b/test/functional/forecast.test.ts
@@ -4,6 +4,7 @@ import stormGlassWeather3HoursFixture from '../fixtures/stormglass_weather_3_hou
 import apiForecastResponse1BeachFixture from '../fixtures/api_forecast_response_1_beach.json';
 import { User } from '@src/models/user';
 import AuthService from '@src/services/auth';
+import CacheUtil from '@src/util/cache';
 
 describe('Beach forecast functional tests', () => {
   const defaultUser: User = {
@@ -25,26 +26,9 @@ describe('Beach forecast functional tests', () => {
     };
     await new Beach(defaultBeach).save();
     token = AuthService.generateToken(user.toJSON());
+    CacheUtil.clearAllCache();
   });
-  // No cache to this test
-  it('should return 500 if something goes wrong during the processing', async () => {
-    nock('https://api.stormglass.io:443', {
-      encodedQueryParams: true,
-      reqheaders: {
-        Authorization: (): boolean => true,
-      },
-    })
-      .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
-      .get('/v1/weather/point')
-      .query({ lat: '-33.792726', lng: '151.289824' })
-      .replyWithError('Something went wrong');
 
-    const { status } = await global.testRequest
-      .get(`/forecast`)
-      .set({ 'x-access-token': token });
-
-    expect(status).toBe(500);
-  });
   it('should return a forecast with just a few times', async () => {
     nock('https://api.stormglass.io:443', {
       encodedQueryParams: true,
@@ -69,5 +53,24 @@ describe('Beach forecast functional tests', () => {
     expect(status).toBe(200);
     // Make sure we use toEqual to check value not the object and array itself
     expect(body).toEqual(apiForecastResponse1BeachFixture);
+  });
+
+  it('should return 500 if something goes wrong during the processing', async () => {
+    nock('https://api.stormglass.io:443', {
+      encodedQueryParams: true,
+      reqheaders: {
+        Authorization: (): boolean => true,
+      },
+    })
+      .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
+      .get('/v1/weather/point')
+      .query({ lat: '-33.792726', lng: '151.289824' })
+      .replyWithError('Something went wrong');
+
+    const { status } = await global.testRequest
+      .get(`/forecast`)
+      .set({ 'x-access-token': token });
+
+    expect(status).toBe(500);
   });
 });

--- a/test/functional/forecast.test.ts
+++ b/test/functional/forecast.test.ts
@@ -26,6 +26,25 @@ describe('Beach forecast functional tests', () => {
     await new Beach(defaultBeach).save();
     token = AuthService.generateToken(user.toJSON());
   });
+  // No cache to this test
+  it('should return 500 if something goes wrong during the processing', async () => {
+    nock('https://api.stormglass.io:443', {
+      encodedQueryParams: true,
+      reqheaders: {
+        Authorization: (): boolean => true,
+      },
+    })
+      .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
+      .get('/v1/weather/point')
+      .query({ lat: '-33.792726', lng: '151.289824' })
+      .replyWithError('Something went wrong');
+
+    const { status } = await global.testRequest
+      .get(`/forecast`)
+      .set({ 'x-access-token': token });
+
+    expect(status).toBe(500);
+  });
   it('should return a forecast with just a few times', async () => {
     nock('https://api.stormglass.io:443', {
       encodedQueryParams: true,
@@ -50,24 +69,5 @@ describe('Beach forecast functional tests', () => {
     expect(status).toBe(200);
     // Make sure we use toEqual to check value not the object and array itself
     expect(body).toEqual(apiForecastResponse1BeachFixture);
-  });
-
-  it('should return 500 if something goes wrong during the processing', async () => {
-    nock('https://api.stormglass.io:443', {
-      encodedQueryParams: true,
-      reqheaders: {
-        Authorization: (): boolean => true,
-      },
-    })
-      .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
-      .get('/v1/weather/point')
-      .query({ lat: '-33.792726', lng: '151.289824' })
-      .replyWithError('Something went wrong');
-
-    const { status } = await global.testRequest
-      .get(`/forecast`)
-      .set({ 'x-access-token': token });
-
-    expect(status).toBe(500);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,6 +739,13 @@
   dependencies:
     nock "*"
 
+"@types/node-cache@^4.2.5":
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/@types/node-cache/-/node-cache-4.2.5.tgz#dac6be8bf8f486db4eef66f52f7bb9e90b65d2c1"
+  integrity sha512-faK2Owokboz53g8ooq2dw3iDJ6/HMTCIa2RvMte5WMTiABy+wA558K+iuyRtlR67Un5q9gEKysSDtqZYbSa0Pg==
+  dependencies:
+    node-cache "*"
+
 "@types/node@*":
   version "14.0.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
@@ -1499,6 +1506,11 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 co@^4.6.0:
   version "4.6.0"
@@ -4057,6 +4069,13 @@ node-addon-api@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.0.tgz#812446a1001a54f71663bed188314bba07e09247"
   integrity sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg==
+
+node-cache@*, node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Hi!
I used node-cache to this task, the TTL of cache can be configured through api configs.
In the stormGlass unit test I tried use `mockedCache.get.mockReturnValue(undefined);` but this didn't work, in the end I used `mockedCache.get = jest.fn().mockReturnValue(undefined);`.
Another point was in the forecast functional test when we try force a http 500 error and with cache this error didn't happen. Therefore I moved this test block to the beginning of the file when the cache wasn't used.
If there are better ways to solve these problems please let me know.

Tks!