### PR TITLE
Change user to userId in Beach relationship

### DIFF
--- a/src/controllers/beaches.ts
+++ b/src/controllers/beaches.ts
@@ -10,7 +10,7 @@ export class BeachesController extends BaseController {
   @Post('')
   public async create(req: Request, res: Response): Promise<void> {
     try {
-      const beach = new Beach({ ...req.body, ...{ user: req.decoded?.id } });
+      const beach = new Beach({ ...req.body, ...{ userId: req.decoded?.id } });
       const result = await beach.save();
       res.status(201).send(result);
     } catch (error) {

--- a/src/controllers/forecast.ts
+++ b/src/controllers/forecast.ts
@@ -41,7 +41,7 @@ export class ForecastController extends BaseController {
     res: Response
   ): Promise<void> {
     try {
-      const beaches = await Beach.find({ user: req.decoded?.id });
+      const beaches = await Beach.find({ userId: req.decoded?.id });
       const forecastData = await forecast.processForecastForBeaches(beaches);
       res.status(200).send(forecastData);
     } catch (error) {

--- a/src/models/beach.ts
+++ b/src/models/beach.ts
@@ -13,16 +13,16 @@ export interface Beach {
   position: GeoPosition;
   lat: number;
   lng: number;
-  user: string;
+  userId: string;
 }
 
-const schema = new mongoose.Schema(
+const schema = new mongoose.Schema<Beach>(
   {
     lat: { type: Number, required: true },
     lng: { type: Number, required: true },
     name: { type: String, required: true },
     position: { type: String, required: true },
-    user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
   },
   {
     toJSON: {

--- a/src/services/__test__/forecast.test.ts
+++ b/src/services/__test__/forecast.test.ts
@@ -38,14 +38,14 @@ describe('Forecast Service', () => {
         lng: 151.289824,
         name: 'Manly',
         position: GeoPosition.E,
-        user: 'fake-id',
+        userId: 'fake-id',
       },
       {
         lat: -33.792726,
         lng: 141.289824,
         name: 'Dee Why',
         position: GeoPosition.S,
-        user: 'fake-id',
+        userId: 'fake-id',
       },
     ];
     const expectedResponse = [
@@ -100,7 +100,7 @@ describe('Forecast Service', () => {
         lng: 151.289824,
         name: 'Manly',
         position: GeoPosition.E,
-        user: 'fake-id',
+        userId: 'fake-id',
       },
     ];
     const expectedResponse = [
@@ -183,7 +183,7 @@ describe('Forecast Service', () => {
         lng: 151.289824,
         name: 'Manly',
         position: GeoPosition.E,
-        user: 'fake-id',
+        userId: 'fake-id',
       },
     ];
     mockedStormGlassService.fetchPoints.mockRejectedValue(

--- a/src/services/__test__/rating.test.ts
+++ b/src/services/__test__/rating.test.ts
@@ -7,7 +7,7 @@ describe('Rating Service', () => {
     lng: 151.289824,
     name: 'Manly',
     position: GeoPosition.E,
-    user: 'some-user',
+    userId: 'some-user',
   };
   const defaultRating = new Rating(defaultBeach);
   describe('Calculate rating for a given point', () => {

--- a/src/services/forecast.ts
+++ b/src/services/forecast.ts
@@ -6,7 +6,7 @@ import { Beach } from '@src/models/beach';
 import logger from '@src/logger';
 import { Rating } from './rating';
 
-export interface BeachForecast extends Omit<Beach, 'user'>, ForecastPoint {
+export interface BeachForecast extends Omit<Beach, 'userId'>, ForecastPoint {
   rating: number;
 }
 

--- a/test/functional/forecast.test.ts
+++ b/test/functional/forecast.test.ts
@@ -16,12 +16,12 @@ describe('Beach forecast functional tests', () => {
     await Beach.deleteMany({});
     await User.deleteMany({});
     const user = await new User(defaultUser).save();
-    const defaultBeach = {
+    const defaultBeach: Beach = {
       lat: -33.792726,
       lng: 151.289824,
       name: 'Manly',
       position: GeoPosition.E,
-      user: user.id,
+      userId: user.id,
     };
     await new Beach(defaultBeach).save();
     token = AuthService.generateToken(user.toJSON());


### PR DESCRIPTION
`userId` is a better naming for relationships where the object is saved in a different table