### PR TITLE
Refactor/beach tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint:fix": "eslint ./src ./test --ext .ts --fix",
     "test:functional": "dotenv -e .env -- jest --projects ./test --runInBand",
     "test:unit": "dotenv -e .env -- jest",
-    "style:check": "prettier --check 'src/**/*.ts' 'test/**/*.ts'",
-    "style:fix": "prettier --write 'src/**/*.ts' 'test/**/*.ts'"
+    "style:check": "prettier --check src/**/*.ts test/**/*.ts",
+    "style:fix": "prettier --write src/**/*.ts' test/**/*.ts"
   },
   "engines": {
     "node": "14"

--- a/src/services/__test__/forecast.test.ts
+++ b/src/services/__test__/forecast.test.ts
@@ -1,13 +1,14 @@
+import { Beach, GeoPosition } from '@src/models/beach';
+import { Forecast, ForecastProcessingInternalError } from '../forecast';
+
 import { StormGlass } from '@src/clients/stormGlass';
 import stormGlassNormalizedResponseFixture from '@test/fixtures/stormglass_normalized_response_3_hours.json';
-import { Forecast, ForecastProcessingInternalError } from '../forecast';
-import { Beach, GeoPosition } from '@src/models/beach';
 
 jest.mock('@src/clients/stormGlass');
 
 describe('Forecast Service', () => {
   const mockedStormGlassService = new StormGlass() as jest.Mocked<StormGlass>;
-  it('should return the forecast for mutiple beaches in the same hour with different ratings ordered by rating decreasing', async () => {
+  it('should return the forecast for multiple beaches in the same hour with different ratings ordered by rating decreasing', async () => {
     mockedStormGlassService.fetchPoints.mockResolvedValueOnce([
       {
         swellDirection: 123.41,
@@ -94,7 +95,7 @@ describe('Forecast Service', () => {
     expect(beachesWithRating).toEqual(expectedResponse);
   });
 
-  it('should return the forecast for mutiple beaches in the same hour with different ratings ordered by rating increasing', async () => {
+  it('should return the forecast for multiple beaches in the same hour with different ratings ordered by rating increasing', async () => {
     mockedStormGlassService.fetchPoints.mockResolvedValueOnce([
       {
         swellDirection: 123.41,
@@ -267,7 +268,7 @@ describe('Forecast Service', () => {
     );
     expect(beachesWithRating).toEqual(expectedResponse);
   });
-  it('should return the forecast for mutiple beaches in the same hour with different lng ordered by decreasing', async () => {
+  it('should return the forecast for multiple beaches in the same hour with different lng ordered by decreasing', async () => {
     mockedStormGlassService.fetchPoints.mockResolvedValueOnce([
       {
         swellDirection: 123.41,

--- a/test/functional/beaches.test.ts
+++ b/test/functional/beaches.test.ts
@@ -1,6 +1,6 @@
+import AuthService from '@src/services/auth';
 import { Beach } from '@src/models/beach';
 import { User } from '@src/models/user';
-import AuthService from '@src/services/auth';
 
 describe('Beaches functional tests', () => {
   const defaultUser = {
@@ -59,7 +59,7 @@ describe('Beaches functional tests', () => {
     it('should return 500 when there is any error other than validation error', async () => {
       jest
         .spyOn(Beach.prototype, 'save')
-        .mockImplementationOnce(() => Promise.reject('fail to create beach'));
+        .mockRejectedValueOnce('fail to create beach');
       const newBeach = {
         lat: -33.792726,
         lng: 46.43243,


### PR DESCRIPTION
Olá, Waldemar. Tudo bem? 
Esse curso foi um grande divisor de águas em minha carreira faz parte das referências na maior parte de meus trabalhos. Não canso de revê-lo (Estou assistindo pela quarta vez) e gostaria de deixar minha contribuição, mesmo que pequena. 

1- No arquivo beaches.test.ts,  é possível usar `mockRejectedValueOnce` em vez de `mockImplementationOnce(() => Promise.reject('fail to create beach'));`

2- Corrigi a palavra multiple, que estava com um erro de gramática: 'mutiple'

3- Estou utilizando o windows e as aspas do script **style:check** estavam quebrando aqui, então pensei em removê-las

Agradeço novamente pelo grande curso e desejo muito sucesso para todos nós!