### PR TITLE
alterando o try catch do getForecastPointsFromApi

### DIFF
--- a/src/clients/stormGlass.ts
+++ b/src/clients/stormGlass.ts
@@ -5,6 +5,7 @@ import * as HTTPUtil from '@src/util/request';
 import { TimeUtil } from '@src/util/time';
 import CacheUtil from '@src/util/cache';
 import logger from '@src/logger';
+import { AxiosError } from 'axios';
 
 export interface StormGlassPointSource {
   [key: string]: number;
@@ -115,18 +116,20 @@ export class StormGlass {
         }
       );
       return this.normalizeResponse(response.data);
-    } catch (err) {
+    } catch (err: unknown) {
       /**
        * This is handling the Axios errors specifically
        */
-      if (HTTPUtil.Request.isRequestError(err)) {
+      const axiosError = err as AxiosError;
+      const errorMessage = err as Error;
+      if (axiosError.response && axiosError.response.data) {
         throw new StormGlassResponseError(
-          `Error: ${JSON.stringify(err.response.data)} Code: ${
-            err.response.status
+          `Error: ${JSON.stringify(axiosError.response.data)} Code: ${
+            axiosError.response.status
           }`
         );
       }
-      throw new ClientRequestError(err.message);
+      throw new ClientRequestError(errorMessage.message);
     }
   }
 


### PR DESCRIPTION
Alterei o try catch tipando a mensagem de erro, não sei se é uma boa prática.
Pois, após a versão 4.0 do TS ele espera que o objeto de erro dentro catch seja em 'unknown' ao invés de 'any'.